### PR TITLE
Jiminy: Update of the configuration

### DIFF
--- a/app/src/routes/api/v1/jiminy.config.js
+++ b/app/src/routes/api/v1/jiminy.config.js
@@ -12,7 +12,9 @@ module.exports = [{
     name: 'line',
     acceptedStatTypes: [
         ['quantitative', 'temporal'],
-        ['quantitative', 'ordinal']
+        ['quantitative', 'ordinal'],
+        ['quantitative', 'quantitative'],
+        ['ordinal', 'ordinal']
     ]
 },
 {


### PR DESCRIPTION
This PR updates the Jiminy configuration so line charts can be built using only numerical columns if needed.

@rrequero Can you accept [this task](https://www.pivotaltracker.com/story/show/154620353) when the PR is merged and deployed?